### PR TITLE
Update Dockerfile update for nginx - patched daily (0 CVEs to low-CVEs)

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM cgr.dev/chainguard/nginx
 
 ARG HOSTNAME
 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/nginx
+FROM cgr.dev/chainguard/nginx:latest
 
 ARG HOSTNAME
 


### PR DESCRIPTION
Updated the **Docker nginx container image.** Instead, we recommend using the latest **Chainguard nginx container image**, which is **free** to use, hardened daily, and actively maintained to eliminate CVEs by patching both direct and transitive dependencies.

If Chainguard's `nginx:latest` image harden daily, the transition should be straightforward—and will significantly reduce software supply chain risk.

See the difference: https://images.chainguard.dev/directory/image/nginx/compare
<img width="1193" alt="Screenshot 2025-05-20 at 2 21 57 PM" src="https://github.com/user-attachments/assets/79ba4efa-63da-4b52-9cbe-b7f970f00f74" />

**Docker**
 ~ grype nginx:alpine                                                     
 ✔ Pulled image                    
 ✔ Loaded image                                                                                                      nginx:alpine 
 ✔ Parsed image                                           sha256:96868d9fa38f469a86d2f25787e43ee9ad330339d30be260aa9f5a338bb03751 
 ✔ Cataloged contents                                            4ea77aed1105f06c21b41d8ebcbfbcaa11e6ce07461b8b3bbcee3d70de786b00 
   ├── ✔ Packages                        [68 packages]  
   ├── ✔ File metadata                   [978 locations]  
   ├── ✔ Executables                     [123 executables]  
   └── ✔ File digests                    [978 files]  
 **✔ Scanned for vulnerabilities     [12 vulnerability matches]  
   ├── by severity: 0 critical, 3 high, 3 medium, 6 low, 0 negligible
   └── by status:   2 fixed, 10 not-fixed, 0 ignored** 
   
NAME           INSTALLED   FIXED-IN   TYPE  VULNERABILITY   SEVERITY  EPSS%  RISK  
tiff           4.7.0-r0               apk   CVE-2023-6277   Medium    60.80    0.2  
tiff           4.7.0-r0               apk   CVE-2023-52356  High      49.60    0.2  
tiff           4.7.0-r0               apk   CVE-2015-7313   Medium    45.05    0.1  
libxml2        2.13.4-r5   2.13.4-r6  apk   CVE-2025-32415  High       3.78  < 0.1  
libxml2        2.13.4-r5   2.13.4-r6  apk   CVE-2025-32414  High       1.83  < 0.1  
tiff           4.7.0-r0               apk   CVE-2023-6228   Medium     2.66  < 0.1  
busybox        1.37.0-r12             apk   CVE-2025-46394  Low        2.25  < 0.1  
busybox-binsh  1.37.0-r12             apk   CVE-2025-46394  Low        2.25  < 0.1  
ssl_client     1.37.0-r12             apk   CVE-2025-46394  Low        2.25  < 0.1  
busybox        1.37.0-r12             apk   CVE-2024-58251  Low        3.11  < 0.1  
busybox-binsh  1.37.0-r12             apk   CVE-2024-58251  Low        3.11  < 0.1  
ssl_client     1.37.0-r12             apk   CVE-2024-58251  Low        3.11  < 0.1

**Chainguard** 
~ grype cgr.dev/chainguard/nginx:latest                                  
 ✔ Loaded image                                                                                   cgr.dev/chainguard/nginx:latest 
 ✔ Parsed image                                           sha256:989aaf169ed087c46f7ef49d9bcc6c83eebb550ac1b69e379406926feb3232db 
 ✔ Cataloged contents                                            65b84f245ad3d56efb85362bf4fb83e7ec82b1104ccfeaed8e2c89050c901751 
   ├── ✔ Packages                        [16 packages]  
   ├── ✔ Executables                     [33 executables]  
   ├── ✔ File metadata                   [165 locations]  
   └── ✔ File digests                    [165 files]  
 **✔ Scanned for vulnerabilities     [0 vulnerability matches]  
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored** 
No vulnerabilities found
